### PR TITLE
fix refactoring file with non-ascii symbol in path

### DIFF
--- a/src/MainHaRe.hs
+++ b/src/MainHaRe.hs
@@ -301,7 +301,7 @@ runFunc f = do
   putStrLn ret
 
 showLisp :: [String] -> String
-showLisp xs = "(" ++ (intercalate " " $ map show xs) ++ ")"
+showLisp xs = "(" ++ (intercalate " " $ map (\str -> "\"" ++ str ++ "\"") xs) ++ ")"
 
 catchException :: (IO t) -> IO (Either String t)
 catchException f = do


### PR DESCRIPTION
Using show for string wrap in quotes is a bad idea. It draws non-ascii symbol as escape sequence and breaks non-latin filepath compatibility. This patch changes showLisp for only wrap string in quotes without symbol escaping.