### PR TITLE
Use unix slashes in returned filenames, emacs can deal with those but…

### DIFF
--- a/src/MainHaRe.hs
+++ b/src/MainHaRe.hs
@@ -301,7 +301,8 @@ runFunc f = do
   putStrLn ret
 
 showLisp :: [String] -> String
-showLisp xs = "(" ++ (intercalate " " $ map (\str -> "\"" ++ str ++ "\"") xs) ++ ")"
+showLisp xs = "(" ++ (intercalate " " $ map (\str -> "\"" ++ unixSlashes str ++ "\"") xs) ++ ")"
+  where unixSlashes = map (\c -> if c == '\\' then '/' else c)
 
 catchException :: (IO t) -> IO (Either String t)
 catchException f = do


### PR DESCRIPTION
… will take backslashes as escape characters