### PR TITLE
Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@
 /testing/evalAddEvalMon/UTestCache
 /testing/introThreshold/UTestCache
 dist/
+dist-newstyle/
 editors/Emacs/haskell-refac.el
 editors/Emacs/haskell-refac.el2
 editors/GenEditorInterfaces
@@ -462,3 +463,4 @@ test/testdata/cabal/cabal3/stack.yaml
 test/testdata/cabal/cabal4/stack.yaml
 test/testdata/cabal/foo/stack.yaml
 test/testdata/stack.yaml
+/cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/src/Language/Haskell/Refact/Refactoring/DupDef.hs
+++ b/src/Language/Haskell/Refact/Refactoring/DupDef.hs
@@ -159,7 +159,7 @@ reallyDoDuplicating pn newName _inscopes = do
           = filter (\d->isFunBindP d || isSimplePatDecl d) $ definingDeclsRdrNames nm [n] ds True False
 
 
-        doDuplicating' :: (SYB.Typeable t,SYB.Data t) => GHC.Name -> t -> GHC.Located GHC.Name -> RefactGhc t
+        doDuplicating' :: (SYB.Data t) => GHC.Name -> t -> GHC.Located GHC.Name -> RefactGhc t
         doDuplicating' newNameGhc t _ln = do
           logm $ "doDuplicating' entered"
           -- logm $ "doDuplicating' entered:t=" ++ SYB.showData SYB.Parser 0 t

--- a/src/Language/Haskell/Refact/Utils/GhcModuleGraph.hs
+++ b/src/Language/Haskell/Refact/Utils/GhcModuleGraph.hs
@@ -8,11 +8,10 @@ module Language.Haskell.Refact.Utils.GhcModuleGraph
   ) where
 
 -- GHC imports
-#if __GLASGOW_HASKELL__ > 710
-import BasicTypes
-#endif
 import Digraph
+#if __GLASGOW_HASKELL__ <= 710
 import FastString
+#endif
 import GHC
 import HscTypes
 import Panic

--- a/src/Language/Haskell/Refact/Utils/Monad.hs
+++ b/src/Language/Haskell/Refact/Utils/Monad.hs
@@ -253,9 +253,13 @@ cabalModuleGraphs = RefactGhc doCabalModuleGraphs
   where
     doCabalModuleGraphs :: (GM.IOish m) => GM.GhcModT m [GM.GmModuleGraph]
     doCabalModuleGraphs = do
-      mcs <- GM.cabalResolvedComponents
-      let graph = map GM.gmcHomeModuleGraph $ Map.elems mcs
-      return $ graph
+      crdl <- GM.cradle
+      case GM.cradleCabalFile crdl of
+        Just _ -> do
+          mcs <- GM.cabalResolvedComponents
+          let graph = map GM.gmcHomeModuleGraph $ Map.elems mcs
+          return $ graph
+        Nothing -> return []
 
 -- ---------------------------------------------------------------------
 

--- a/src/Language/Haskell/Refact/Utils/Monad.hs
+++ b/src/Language/Haskell/Refact/Utils/Monad.hs
@@ -97,7 +97,7 @@ logSettings = defaultSettings { rsetVerboseLevel = Debug }
 data RefactStashId = Stash !String deriving (Show,Eq,Ord)
 
 data RefactModule = RefMod
-        { rsTypecheckedMod  :: !GHC.TypecheckedModule
+        { rsTypecheckedMod  :: !TypecheckedModule
         , rsNameMap         :: NameMap
           -- ^ Mapping from the names in the ParsedSource to the renamed
           -- versions. Note: No strict mark, can be computed lazily.
@@ -167,7 +167,7 @@ type Targets = [Either FilePath GHC.ModuleName]
 
 -- |Result of parsing a Haskell source file. It is simply the
 -- TypeCheckedModule produced by GHC.
-type ParseResult = GHC.TypecheckedModule
+type ParseResult = TypecheckedModule
 
 -- |Provide some temporary storage while the refactoring is taking
 -- place

--- a/src/Language/Haskell/Refact/Utils/MonadFunctions.hs
+++ b/src/Language/Haskell/Refact/Utils/MonadFunctions.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-} -- For HasTransform
 
 -- |
 

--- a/src/Language/Haskell/Refact/Utils/MonadFunctions.hs
+++ b/src/Language/Haskell/Refact/Utils/MonadFunctions.hs
@@ -112,7 +112,7 @@ fetchAnnsFinal = do
 
 -- ---------------------------------------------------------------------
 
-getTypecheckedModule :: RefactGhc GHC.TypecheckedModule
+getTypecheckedModule :: RefactGhc TypecheckedModule
 getTypecheckedModule = do
   mtm <- gets rsModule
   case mtm of
@@ -140,7 +140,7 @@ getRefactRenamed :: RefactGhc GHC.RenamedSource
 getRefactRenamed = do
   mtm <- gets rsModule
   let tm = gfromJust "getRefactRenamed" mtm
-  return $ gfromJust "getRefactRenamed2" $ GHC.tm_renamed_source $ rsTypecheckedMod tm
+  return $ tmRenamedSource $ rsTypecheckedMod tm
 
 putRefactRenamed :: GHC.RenamedSource -> RefactGhc ()
 putRefactRenamed renamed = do
@@ -148,7 +148,7 @@ putRefactRenamed renamed = do
   mrm <- gets rsModule
   let rm = gfromJust "putRefactRenamed" mrm
   let tm = rsTypecheckedMod rm
-  let tm' = tm { GHC.tm_renamed_source = Just renamed }
+  let tm' = tm { tmRenamedSource = renamed }
   let rm' = rm { rsTypecheckedMod = tm' }
   put $ st {rsModule = Just rm'}
 
@@ -158,7 +158,7 @@ getRefactParsed = do
   let tm = gfromJust "getRefactParsed" mtm
   let t  = rsTypecheckedMod tm
 
-  let pm = GHC.tm_parsed_module t
+  let pm = tmParsedModule t
   return $ GHC.pm_parsed_source pm
 
 putRefactParsed :: GHC.ParsedSource -> Anns -> RefactGhc ()
@@ -171,8 +171,8 @@ putRefactParsed parsed newAnns = do
   -- let tk' = modifyAnns (rsTokenCache rm) (const newAnns)
   let tk' = modifyAnns (rsTokenCache rm) (mergeAnns newAnns)
 
-  let pm = (GHC.tm_parsed_module tm) { GHC.pm_parsed_source = parsed }
-  let tm' = tm { GHC.tm_parsed_module = pm }
+  let pm = (tmParsedModule tm) { GHC.pm_parsed_source = parsed }
+  let tm' = tm { tmParsedModule = pm }
   let rm' = rm { rsTypecheckedMod = tm', rsTokenCache = tk', rsStreamModified = RefacModified }
   put $ st {rsModule = Just rm'}
 
@@ -214,7 +214,7 @@ modifyAnns tk f = tk'
 
 -- ----------------------------------------------------------------------
 
-putParsedModule :: [Comment] -> GHC.TypecheckedModule -> RefactGhc ()
+putParsedModule :: [Comment] -> TypecheckedModule -> RefactGhc ()
 putParsedModule cppComments tm = do
   st <- get
   put $ st { rsModule = initRefactModule cppComments tm }
@@ -313,7 +313,7 @@ getRefactFileName = do
   case mtm of
     Nothing  -> return Nothing
     Just tm -> return $ Just (fileNameFromModSummary $ GHC.pm_mod_summary
-                              $ GHC.tm_parsed_module $ rsTypecheckedMod tm)
+                              $ tmParsedModule $ rsTypecheckedMod tm)
 
 -- ---------------------------------------------------------------------
 
@@ -333,7 +333,7 @@ getRefactModule = do
     Nothing  -> error $ "Hare.MonadFunctions.getRefactModule:no module loaded"
     Just tm -> do
       let t  = rsTypecheckedMod tm
-      let pm = GHC.tm_parsed_module t
+      let pm = tmParsedModule t
       return (GHC.ms_mod $ GHC.pm_mod_summary pm)
 
 -- ---------------------------------------------------------------------
@@ -428,14 +428,14 @@ logParsedSource str = do
 
 -- ---------------------------------------------------------------------
 
-initRefactModule :: [Comment] -> GHC.TypecheckedModule -> Maybe RefactModule
+initRefactModule :: [Comment] -> TypecheckedModule -> Maybe RefactModule
 initRefactModule cppComments tm
   = Just (RefMod { rsTypecheckedMod = tm
                  , rsNameMap = initRdrNameMap tm
                  , rsTokenCache = initTokenCacheLayout (relativiseApiAnnsWithComments
                                      cppComments
-                                    (GHC.pm_parsed_source $ GHC.tm_parsed_module tm)
-                                    (GHC.pm_annotations $ GHC.tm_parsed_module tm))
+                                    (GHC.pm_parsed_source $ tmParsedModule tm)
+                                    (GHC.pm_annotations $ tmParsedModule tm))
                  , rsStreamModified = RefacUnmodifed
                  })
 
@@ -452,13 +452,13 @@ initTokenCacheLayout a = TK (Map.fromList [((TId 0),a)]) (TId 0)
 -- with the wrinkle that we need to Location of the RdrName to make sure we have
 -- the right Name, but not all RdrNames have a Location.
 -- This function is called before the RefactGhc monad is active.
-initRdrNameMap :: GHC.TypecheckedModule -> NameMap
+initRdrNameMap :: TypecheckedModule -> NameMap
 initRdrNameMap tm = r
   where
-    parsed  = GHC.pm_parsed_source $ GHC.tm_parsed_module tm
-    renamed = gfromJust "initRdrNameMap" $ GHC.tm_renamed_source tm
+    parsed  = GHC.pm_parsed_source $ tmParsedModule tm
+    renamed = tmRenamedSource tm
 #if __GLASGOW_HASKELL__ > 710
-    typechecked = GHC.tm_typechecked_source tm
+    typechecked = tmTypecheckedSource tm
 #endif
 
     checkRdr :: GHC.Located GHC.RdrName -> Maybe [(GHC.SrcSpan,GHC.RdrName)]

--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -265,7 +265,7 @@ equivalentNameInNewMod old = do
   logm $ "equivalentNameInNewMod:gnames=" ++ showGhcQual (map (\n -> (GHC.nameModule n,n)) gnames)
   let clientModule = GHC.nameModule old
   logm $ "equivalentNameInNewMod:(old,clientModule)=" ++ showGhcQual (old,clientModule)
-  let clientInscopes = filter (\n -> clientModule == GHC.nameModule n) gnames
+  -- let clientInscopes = filter (\n -> clientModule == GHC.nameModule n) gnames
   let clientInscopes = filter (\n -> eqModules clientModule (GHC.nameModule n)) gnames
   logm $ "equivalentNameInNewMod:clientInscopes=" ++ showGhcQual clientInscopes
   let newNames = filter (\n -> showGhcQual n == showGhcQual old) clientInscopes

--- a/src/Language/Haskell/Refact/Utils/Types.hs
+++ b/src/Language/Haskell/Refact/Utils/Types.hs
@@ -4,6 +4,7 @@ module Language.Haskell.Refact.Utils.Types
        (
         ApplyRefacResult
        , RefacResult(..)
+       , TypecheckedModule(..)
        -- *
        , TreeId(..)
        , mainTid
@@ -14,9 +15,9 @@ module Language.Haskell.Refact.Utils.Types
 
        ) where
 
+import qualified Avail      as GHC
 import qualified GHC        as GHC
--- import qualified Name       as GHC
--- import qualified Outputable as GHC
+import qualified RdrName    as GHC
 
 import Language.Haskell.GHC.ExactPrint
 -- import Language.Haskell.GHC.ExactPrint.Utils
@@ -31,6 +32,20 @@ type ApplyRefacResult = ((FilePath, RefacResult), (Anns,GHC.ParsedSource))
 
 data RefacResult = RefacModified | RefacUnmodifed
                  deriving (Show,Ord,Eq)
+
+-- ---------------------------------------------------------------------
+
+data TypecheckedModule = TypecheckedModule
+  { tmParsedModule      :: !GHC.ParsedModule
+  , tmRenamedSource     :: !GHC.RenamedSource
+  , tmTypecheckedSource :: !GHC.TypecheckedSource
+  , tmMinfExports       :: ![GHC.AvailInfo]
+  , tmMinfRdrEnv        :: !(Maybe GHC.GlobalRdrEnv)   -- Nothing for a compiled/package mod
+  }
+
+-- TODO: improve this, or remove it's need
+instance Show TypecheckedModule where
+  show _ = "TypeCheckedModule(..)"
 
 -- ---------------------------------------------------------------------
 

--- a/src/Language/Haskell/Refact/Utils/Types.hs
+++ b/src/Language/Haskell/Refact/Utils/Types.hs
@@ -39,8 +39,10 @@ data TypecheckedModule = TypecheckedModule
   { tmParsedModule      :: !GHC.ParsedModule
   , tmRenamedSource     :: !GHC.RenamedSource
   , tmTypecheckedSource :: !GHC.TypecheckedSource
-  , tmMinfExports       :: ![GHC.AvailInfo]
-  , tmMinfRdrEnv        :: !(Maybe GHC.GlobalRdrEnv)   -- Nothing for a compiled/package mod
+  -- , tmMinfExports       :: ![GHC.AvailInfo]
+  -- , tmMinfRdrEnv        :: !(Maybe GHC.GlobalRdrEnv)   -- Nothing for a compiled/package mod
+  , tmMinfExports       :: [GHC.AvailInfo]
+  , tmMinfRdrEnv        :: (Maybe GHC.GlobalRdrEnv)   -- Nothing for a compiled/package mod
   }
 
 -- TODO: improve this, or remove it's need

--- a/src/Language/Haskell/Refact/Utils/Utils.hs
+++ b/src/Language/Haskell/Refact/Utils/Utils.hs
@@ -387,6 +387,7 @@ writeRefactoredFiles verbosity files
 
 -- clientModsAndFiles :: GHC.ModuleName -> RefactGhc [TargetModule]
 clientModsAndFiles :: GM.ModulePath -> RefactGhc [TargetModule]
+-- TODO: Use ghc-mod cache if there is a cabal file, else normal GHC modulegraph
 clientModsAndFiles m = do
   mgs <- cabalModuleGraphs
   -- logm $ "clientModsAndFiles:mgs=" ++ show mgs
@@ -433,9 +434,10 @@ mycomp ms1 ms2 = (GHC.ms_mod ms1) == (GHC.ms_mod ms2)
 -- | Return the server module and file names. The server modules of
 -- module, say m, are those modules which are directly or indirectly
 -- imported by module m. This can only be called in a live GHC session
--- TODO: make sure this works with multiple targets. Is that needed? No?
+-- TODO: make sure this works with multiple targets. Is that needed?
 serverModsAndFiles
   :: GHC.GhcMonad m => GHC.ModuleName -> m [GHC.ModSummary]
+-- TODO: Use ghc-mod cache if there is a cabal file, else normal GHC modulegraph
 serverModsAndFiles m = do
   ms <- GHC.getModuleGraph
   modsum <- GHC.getModSummary m

--- a/src/Language/Haskell/Refact/Utils/Variables.hs
+++ b/src/Language/Haskell/Refact/Utils/Variables.hs
@@ -71,7 +71,6 @@ import Language.Haskell.GHC.ExactPrint.Utils
 import qualified Bag           as GHC
 import qualified GHC           as GHC
 import qualified Name          as GHC
-import qualified Outputable    as GHC
 import qualified RdrName       as GHC
 
 import qualified Data.Generics as SYB

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -104,8 +104,8 @@ parsedFileGhc fileName = do
        res <- parseSourceFileTest fileName
        -- logm $ "parsedFileGhc:done"
        return res
-  (parseResult,_s) <- runRefactGhcStateLog comp Normal
-  -- (parseResult,_s) <- runRefactGhcStateLog comp Debug
+  -- (parseResult,_s) <- runRefactGhcStateLog comp Normal
+  (parseResult,_s) <- runRefactGhcStateLog comp Debug
   return parseResult
 
 -- ---------------------------------------------------------------------
@@ -255,7 +255,7 @@ showAnnDataFromState st =
     Just tm -> r
       where
         anns = tkCache (rsTokenCache tm) Map.! mainTid
-        parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module
+        parsed = GHC.pm_parsed_source $ tmParsedModule
                  $ rsTypecheckedMod tm
         r = showAnnData anns 0 parsed
     Nothing -> []
@@ -304,7 +304,7 @@ sourceFromState st =
     Just tm -> r
       where
         anns = tkCache (rsTokenCache tm) Map.! mainTid
-        parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module
+        parsed = GHC.pm_parsed_source $ tmParsedModule
                  $ rsTypecheckedMod tm
         r = exactPrint parsed anns
     Nothing -> []

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -104,8 +104,8 @@ parsedFileGhc fileName = do
        res <- parseSourceFileTest fileName
        -- logm $ "parsedFileGhc:done"
        return res
-  -- (parseResult,_s) <- runRefactGhcStateLog comp Normal
-  (parseResult,_s) <- runRefactGhcStateLog comp Debug
+  (parseResult,_s) <- runRefactGhcStateLog comp Normal
+  -- (parseResult,_s) <- runRefactGhcStateLog comp Debug
   return parseResult
 
 -- ---------------------------------------------------------------------

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -22,6 +22,7 @@ import Language.Haskell.Refact.Utils.LocUtils
 import Language.Haskell.Refact.Utils.Monad
 import Language.Haskell.Refact.Utils.MonadFunctions
 import Language.Haskell.Refact.Utils.TypeUtils
+import Language.Haskell.Refact.Utils.Types
 import Language.Haskell.Refact.Utils.Utils
 import Language.Haskell.Refact.Utils.Variables
 
@@ -41,7 +42,7 @@ spec = do
   describe "locToExp on ParsedSource" $ do
     it "p:finds the largest leftmost expression contained in a given region #1" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/B.hs"
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
 
       let (Just expr) = locToExp (7,7) (7,43) parsed :: Maybe (GHC.Located (GHC.HsExpr GHC.RdrName))
       getLocatedStart expr `shouldBe` (7,9)
@@ -50,7 +51,7 @@ spec = do
     it "p:finds the largest leftmost expression contained in a given region #2" $ do
       -- ((_, _, mod), toks) <- parsedFileBGhc
       t <- ct $ parsedFileGhc "./TypeUtils/B.hs"
-      let modu = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let modu = GHC.pm_parsed_source $ tmParsedModule t
 
       let (Just expr) = locToExp (7,7) (7,41) modu :: Maybe (GHC.Located (GHC.HsExpr GHC.RdrName))
       getLocatedStart expr `shouldBe` (7,12)
@@ -58,7 +59,7 @@ spec = do
 
     it "finds the largest leftmost expression in RenamedSource" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/B.hs"
-      let renamed = fromJust $ GHC.tm_renamed_source t
+      let renamed = tmRenamedSource t
 
       let (Just expr) = locToExp (7,7) (7,41) renamed :: Maybe (GHC.Located (GHC.HsExpr GHC.Name))
       getLocatedStart expr `shouldBe` (7,12)
@@ -68,7 +69,7 @@ spec = do
     it "r:finds the largest leftmost expression contained in a given region #1" $ do
       -- ((_, Just renamed, _), toks) <- parsedFileBGhc
       t <- ct $ parsedFileGhc "./TypeUtils/B.hs"
-      let renamed = fromJust $ GHC.tm_renamed_source t
+      let renamed = tmRenamedSource t
 
       let (Just expr) = locToExp (7,7) (7,43) renamed :: Maybe (GHC.Located (GHC.HsExpr GHC.Name))
       getLocatedStart expr `shouldBe` (7,9)
@@ -80,14 +81,14 @@ spec = do
     it "loads a file having the LANGUAGE CPP pragma" $ do
       t <- ct $ parsedFileGhc "./BCpp.hs"
 
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
       (showGhc parsed) `shouldBe` "module BCpp where\nbob :: Int -> Int -> Int\nbob x y = x + y"
 
      -- ---------------------------------
     it "loads a file having a top comment and LANGUAGE CPP pragma" $ do
       t <- ct $ parsedFileGhc "./BCppTC.hs"
 
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
       (showGhc parsed) `shouldBe` "module BCppTC where\nbob :: Int -> Int -> Int\nbob x y = x + y"
 
      -- ---------------------------------
@@ -356,14 +357,14 @@ spec = do
   describe "getModuleName" $ do
     it "returns a string for the module name if there is one" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/B.hs"
-      let modu = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let modu = GHC.pm_parsed_source $ tmParsedModule t
 
       let (Just (_modname,modNameStr)) = getModuleName modu
       modNameStr `shouldBe` "TypeUtils.B"
 
     it "returns Nothing for the module name otherwise" $ do
       t <- ct $ parsedFileGhc "./NoMod.hs"
-      let modu = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let modu = GHC.pm_parsed_source $ tmParsedModule t
       getModuleName modu `shouldBe` Nothing
 
   -- -------------------------------------------------------------------
@@ -539,7 +540,7 @@ spec = do
           return (pr,g)
 
       ( (t, mg), _s) <- ct $ runRefactGhc comp initialState testOptions
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
 
       (show $ getModuleName parsed) `shouldBe` "Just (ModuleName \"S1\",\"S1\")"
       showGhc (map GM.mpModule mg) `shouldBe` "[Main, M3, M2]"
@@ -556,7 +557,7 @@ spec = do
 
           return (pr,g)
       ((t, mg ), _s) <- ct $ runRefactGhc comp initialState testOptions
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
 
       (show $ getModuleName parsed) `shouldBe` "Just (ModuleName \"S1\",\"S1\")"
       showGhc (map GM.mpModule mg) `shouldBe` "[Main, M3, M2]"
@@ -573,7 +574,7 @@ spec = do
 
           return (pr,g)
       ((t, mg), _s) <- ct $ runRefactGhc comp  initialState testOptions
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
       (show $ getModuleName parsed) `shouldBe` "Just (ModuleName \"DupDef.Dd1\",\"DupDef.Dd1\")"
       showGhc (map GM.mpModule mg) `shouldBe` "[DupDef.Dd2, DupDef.Dd3]"
 
@@ -638,7 +639,7 @@ spec = do
     it "loads a file from a sub directory" $ do
       t <- ct $ parsedFileGhc "./FreeAndDeclared/DeclareS.hs"
       fileName <- canonicalizePath "./test/testdata/FreeAndDeclared/DeclareS.hs"
-      let parsed = GHC.pm_parsed_source $ GHC.tm_parsed_module t
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
       let
         comp = do
           parseSourceFileGhc fileName

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -164,11 +164,8 @@ spec = do
       let
         comp = do
          parseSourceFileGhc testFileName
-         logm $ "after parseSourceFileGhc"
          tm <- getRefactTargetModule
-         logm $ "after getRefactTargetModule"
          g <- clientModsAndFiles tm
-         logm $ "after clientModsAndFiles"
          return g
       (mg,_s) <- cdAndDo testDir $ runRefactGhc comp initialState testOptions
       -- (mg,_s) <- cdAndDo testDir $ runRefactGhc comp initialLogOnState testOptions


### PR DESCRIPTION
Use GHC hooks to pull out the `TypeCheckedSource` for the module being refactored.

This avoids re-parsing it after `ghc-mod` already does that as part of loading the target.