### PR TITLE
Rename datatype constructor

### DIFF
--- a/src/Language/Haskell/Refact/API.hs
+++ b/src/Language/Haskell/Refact/API.hs
@@ -130,6 +130,8 @@ module Language.Haskell.Refact.API
     , hsFDsFromInsideRdr, hsFDNamesFromInsideRdr, hsFDNamesFromInsideRdrPure
     , hsVisibleDsRdr
     , rdrName2Name, rdrName2NamePure
+    , eqRdrNamePure
+    , sameNameSpace
 
     -- *** Property checking
     ,isVarId,isConId,isOperator,isTopLevelPN,isLocalPN,isNonLibraryName -- ,isTopLevelPNT

--- a/src/Language/Haskell/Refact/Utils/Variables.hs
+++ b/src/Language/Haskell/Refact/Utils/Variables.hs
@@ -31,6 +31,7 @@ module Language.Haskell.Refact.Utils.Variables
   , rdrName2Name, rdrName2NamePure
   , eqRdrNamePure
   -- , rdrName2Name'
+  , sameNameSpace
 
   -- ** Identifiers, expressions, patterns and declarations
   , FindEntity(..)
@@ -1552,6 +1553,13 @@ rdrName2NamePure nameMap (GHC.L lrn _) =
 eqRdrNamePure :: NameMap -> GHC.Located GHC.RdrName -> GHC.Name -> Bool
 eqRdrNamePure nameMap rn n
   = GHC.nameUnique (rdrName2NamePure nameMap rn) == GHC.nameUnique n
+
+-- ---------------------------------------------------------------------
+
+-- | Returns True if both @GHC.Name@s are in the same @GHC.NameSpace@.
+sameNameSpace :: GHC.Name -> GHC.Name -> Bool
+sameNameSpace n1 n2
+  = (GHC.occNameSpace $ GHC.nameOccName n1) == (GHC.occNameSpace $ GHC.nameOccName n2)
 
 -- ---------------------------------------------------------------------
 

--- a/test/RenamingSpec.hs
+++ b/test/RenamingSpec.hs
@@ -301,6 +301,18 @@ spec = do
 
     -- ---------------------------------
 
+    it "renames in Constructor 5 16" $ do
+     r <- ct $ rename defaultTestSettings testOptions "./Renaming/Constructor.hs" "MyType" (5,16)
+     -- ct $ rename logTestSettings testOptions "./Renaming/Constructor.hs" "MyType" (5,16)
+     r' <- ct $ mapM makeRelativeToCurrentDirectory r
+     r' `shouldBe` [ "Renaming/Constructor.hs"
+                  ]
+     diff <- ct $ compareFiles "./Renaming/Constructor.expected.hs"
+                               "./Renaming/Constructor.refactored.hs"
+     diff `shouldBe` []
+
+    -- ---------------------------------
+
     it "renames in LayoutIn1 7 17" $ do
      r <- ct $ rename defaultTestSettings testOptions "./Renaming/LayoutIn1.hs" "square" (7,17)
      -- ct $ rename logTestSettings testOptions "./Renaming/LayoutIn1.hs" "square" (7,17)

--- a/test/testdata/Renaming/Constructor.expected.hs
+++ b/test/testdata/Renaming/Constructor.expected.hs
@@ -1,0 +1,9 @@
+module Constructor where
+
+-- Should be able to rename AType to MyType, as they are in different name
+-- spaces
+data MyType = MyType Int | YourType Bool
+
+foo :: MyType -> Bool
+foo (MyType i)   = i > 0
+foo (YourType b) = b

--- a/test/testdata/Renaming/Constructor.hs
+++ b/test/testdata/Renaming/Constructor.hs
@@ -1,0 +1,9 @@
+module Constructor where
+
+-- Should be able to rename AType to MyType, as they are in different name
+-- spaces
+data MyType = AType Int | YourType Bool
+
+foo :: MyType -> Bool
+foo (AType i)   = i > 0
+foo (YourType b) = b


### PR DESCRIPTION
Distringuish between type namespace and constructor namespace when checking for name clashes.
