### PR TITLE
Issue 41 incorrect renaming

### DIFF
--- a/src/Language/Haskell/Refact/Refactoring/Renaming.hs
+++ b/src/Language/Haskell/Refact/Refactoring/Renaming.hs
@@ -291,6 +291,7 @@ condChecking2 nm oldPN newName t = do
              ::GHC.Match GHC.RdrName (GHC.LHsExpr GHC.RdrName)) = do
       isDeclaredPats <- isDeclaredBy pats
       isDeclaredDs   <- isDeclaredBy ds
+      logm $ "Renaming.condChecking2.inMatch:isDeclared=" ++ show (isDeclaredPats,isDeclaredDs)
       if isDeclaredPats
         then condChecking' (GHC.Match f pats mtype (GHC.GRHSs rhs ds))
         else if isDeclaredDs
@@ -317,8 +318,9 @@ condChecking2 nm oldPN newName t = do
         then condChecking' expr
         else mzero
     inExp expr@((GHC.L _ (GHC.HsDo _ ds e)):: GHC.LHsExpr GHC.RdrName) = do
-      -- isDeclared   <- isDeclaredBy ds
-      isDeclared   <- isDeclaredBy expr
+      isDeclared   <- isDeclaredBy ds
+      -- logDataWithAnns "inExp.HsDo:expr" expr
+      logm $ "inExp.HsDo:isDeclared=" ++ show isDeclared
       if isDeclared
         then condChecking' expr
         else mzero
@@ -399,6 +401,7 @@ condChecking2 nm oldPN newName t = do
       -- DN vd <- hsVisibleDsRdr nm oldPN t
       -- logm $ "condChecking':vd=" ++ showGhc vd
       sameGroupDecls <- declaredVarsInSameGroup nm oldPN t
+      logm $ "condChecking':sameGroupDecls=" ++ showGhc sameGroupDecls
       when (newName `elem` sameGroupDecls)
             $ error "The new name exists in the same binding group!"
       (f, d) <- hsFreeAndDeclaredNameStrings t
@@ -407,7 +410,7 @@ condChecking2 nm oldPN newName t = do
       -- are visible to the places where oldPN occurs.
       ds <- hsVisibleNamesRdr oldPN t
       -- logm $ "Renaming.condChecking':t=" ++ showGhc t
-      -- logm $ "Renaming.condChecking':ds=" ++ showGhc ds
+      logm $ "Renaming.condChecking':ds=" ++ showGhc ds
       when (newName `elem` ds) $ error "The new name will cause name capture!"
       return t
 

--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -1074,7 +1074,7 @@ addItemsToImport ::
   -> Either [GHC.RdrName] [GHC.LIE GHC.RdrName] -- ^ The items to be added
   -> GHC.ParsedSource      -- ^ The current module
   -> RefactGhc GHC.ParsedSource -- ^ The result
-addItemsToImport mn mc ns r = addItemsToImport' mn r ns Import
+addItemsToImport mn _mc ns r = addItemsToImport' mn r ns Import
 
 -- | Add identifiers (given by the third argument) to the explicit entity list
 --   in the declaration importing the specified module name. If the ImportType

--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -407,7 +407,7 @@ causeNameClashInExports::  NameMap
                         -> GHC.Name          -- ^ The original name
                         -> GHC.Name          -- ^ The new name
                         -> GHC.ModuleName    -- ^ The identity of the module
-                        -> GHC.ParsedSource -- ^ The AST of the module
+                        -> GHC.ParsedSource  -- ^ The AST of the module
                         -> Bool              -- ^ The result
 
 -- Note that in the abstract representation of exps, there is no qualified entities.
@@ -1830,10 +1830,10 @@ rmDecl:: (SYB.Data t)
 
 rmDecl pn incSig t = do
   setStateStorage StorageNone
-  t' <- everywhereMStaged' SYB.Parser (SYB.mkM   inModule
-                                      `SYB.extM` inLet
-                                      `SYB.extM` inMatch
-                                      ) t -- top down
+  t' <- everywhereM' (SYB.mkM   inModule
+                     `SYB.extM` inLet
+                     `SYB.extM` inMatch
+                     ) t -- top down
          -- applyTP (once_tdTP (failTP `adhocTP` inBinds)) t
   storage <- getStateStorage
   let decl' = case storage of

--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -209,19 +209,19 @@ isInScopeAndUnqualifiedGhc ::
   -> RefactGhc Bool   -- ^ The result.
 isInScopeAndUnqualifiedGhc n maybeExising = do
   names <- ghandle handler (GHC.parseName n)
-  logm $ "isInScopeAndUnqualifiedGhc:(n,(maybeExising,names))=" ++ (show n) ++ ":" ++  (showGhc (maybeExising,names))
+  -- logm $ "isInScopeAndUnqualifiedGhc:(n,(maybeExising,names))=" ++ (show n) ++ ":" ++  (showGhc (maybeExising,names))
   ctx <- GHC.getContext
-  logm $ "isInScopeAndUnqualifiedGhc:ctx=" ++ (showGhc ctx)
+  -- logm $ "isInScopeAndUnqualifiedGhc:ctx=" ++ (showGhc ctx)
   let nameList = case maybeExising of
                   Nothing -> names
                   Just n' -> filter (\x -> (showGhcQual x) /= (showGhcQual n')) names
-  logm $ "isInScopeAndUnqualifiedGhc:(n,nameList)=" ++ (show n) ++ ":" ++  (showGhc nameList)
+  -- logm $ "isInScopeAndUnqualifiedGhc:(n,nameList)=" ++ (show n) ++ ":" ++  (showGhc nameList)
   return $ nameList /= []
 
   where
     handler:: SomeException -> RefactGhc [GHC.Name]
     handler e = do
-      logm $ "isInScopeAndUnqualifiedGhc.handler e=" ++ (show e)
+      -- logm $ "isInScopeAndUnqualifiedGhc.handler e=" ++ (show e)
       return []
 
 -- ---------------------------------------------------------------------

--- a/src/Language/Haskell/Refact/Utils/Utils.hs
+++ b/src/Language/Haskell/Refact/Utils/Utils.hs
@@ -178,10 +178,10 @@ hscFrontend ref mod_summary = do
                                 (GHC.hpm_src_files   hpm)
                                 (GHC.hpm_annotations hpm)
 
-        hsc_env <- GHC.getHscEnv
-        (tc_gbl_env,rn_info) <- liftIO $ GHC.hscTypecheckRename hsc_env mod_summary hpm
+        hsc_env' <- GHC.getHscEnv
+        (tc_gbl_env,rn_info) <- liftIO $ GHC.hscTypecheckRename hsc_env' mod_summary hpm
 
-        details <- liftIO $ GHC.makeSimpleDetails hsc_env tc_gbl_env
+        details <- liftIO $ GHC.makeSimpleDetails hsc_env' tc_gbl_env
 
         let
           tc =
@@ -275,8 +275,8 @@ loadFromModSummary mtm modSum = do
       settings <- get
       put $ settings { rsCurrentTarget = Just newTargetModule }
 
-  mtm <- gets rsModule
-  case mtm of
+  mtm' <- gets rsModule
+  case mtm' of
     Just tm -> if ((rsStreamModified tm == RefacUnmodifed)
                   && oldTargetModule == Just newTargetModule)
                  then do

--- a/test/RenamingSpec.hs
+++ b/test/RenamingSpec.hs
@@ -207,7 +207,7 @@ spec = do
 
     it "renames in Field4 5 23" $ do
      r <- ct $ rename defaultTestSettings testOptions "./Renaming/Field4.hs" "value2" (5,23)
-     -- ct $ rename logTestSettings Nothing "./Renaming/Field4.hs" "value2" (5,23)
+     -- ct $ rename logTestSettings testOptions "./Renaming/Field4.hs" "value2" (5,23)
      r' <- ct $ mapM makeRelativeToCurrentDirectory r
      r' `shouldBe` [ "Renaming/Field4.hs"
                   ]
@@ -327,7 +327,7 @@ spec = do
 
     it "renames in LayoutIn2 8 7" $ do
      r <- ct $ rename defaultTestSettings testOptions "./Renaming/LayoutIn2.hs" "ls" (8,7)
-     -- ct $ rename logTestSettings testOptions Nothing "./Renaming/LayoutIn2.hs" "ls" (8,7)
+     -- ct $ rename logTestSettings testOptions "./Renaming/LayoutIn2.hs" "ls" (8,7)
      r' <- ct $ mapM makeRelativeToCurrentDirectory r
      r' `shouldBe` [ "Renaming/LayoutIn2.hs"
                   ]

--- a/test/RenamingSpec.hs
+++ b/test/RenamingSpec.hs
@@ -419,6 +419,14 @@ spec = do
 
     -- ---------------------------------
 
+    it "cannot rename x InScopes" $ do
+     -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
+     res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
+     show res `shouldBe` "Just \"The 'main' function defined in a 'Main' module should not be renamed!\""
+
+
+    -- ---------------------------------
+
     it "rename with default main Main2" $ do
      -- ct $ rename logTestSettings testOptions "./Renaming/Main2.hs" "baz" (6,1)
      r <- ct $ rename defaultTestSettings testOptions "./Renaming/Main2.hs" "baz" (6,1)

--- a/test/RenamingSpec.hs
+++ b/test/RenamingSpec.hs
@@ -419,11 +419,31 @@ spec = do
 
     -- ---------------------------------
 
-    it "cannot rename x InScopes" $ do
+    it "cannot rename x InScopes 1" $ do
      -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
      res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
-     show res `shouldBe` "Just \"Still need to clarify what error should be reported. But there should be one.\""
+     show res `shouldBe` "Just \"The new name will cause name capture!\""
 
+    -- ---------------------------------
+
+    it "cannot rename x InScopes 2" $ do
+     -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (10,10))
+     res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (10,10))
+     show res `shouldBe` "Just \"The new name will cause name capture!\""
+
+    -- ---------------------------------
+
+    it "cannot rename x InScopes 3" $ do
+     -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (12,8))
+     res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (12,8))
+     show res `shouldBe` "Just \"The new name will cause name capture!\""
+
+    -- ---------------------------------
+
+    it "cannot rename x InScopes 4" $ do
+     -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (21,12))
+     res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (21,12))
+     show res `shouldBe` "Just \"The new name will cause name capture!\""
 
     -- ---------------------------------
 

--- a/test/RenamingSpec.hs
+++ b/test/RenamingSpec.hs
@@ -422,7 +422,7 @@ spec = do
     it "cannot rename x InScopes" $ do
      -- res <- catchException (ct $ rename logTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
      res <- catchException (ct $ rename defaultTestSettings testOptions "./Renaming/InScopes.hs" "g" (6,22))
-     show res `shouldBe` "Just \"The 'main' function defined in a 'Main' module should not be renamed!\""
+     show res `shouldBe` "Just \"Still need to clarify what error should be reported. But there should be one.\""
 
 
     -- ---------------------------------

--- a/test/TypeUtilsSpec.hs
+++ b/test/TypeUtilsSpec.hs
@@ -558,7 +558,7 @@ spec = do
 
     -- ---------------------------------
 
-    it "finds declared HsVar" $ do
+    it "finds free and declared variables" $ do
       t <- ct $ parsedFileGhc "./FreeAndDeclared/Declare.hs"
       let
         comp = do
@@ -566,10 +566,9 @@ spec = do
           nm <- getRefactNameMap
           logDataWithAnns "parsed:"  parsed
           let rr = hsFreeAndDeclaredRdr nm parsed
-          rg <-    hsFreeAndDeclaredPNs    parsed
-          return (rg,rr)
-      -- ((resg,(FN fr,DN dr)),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
-      ((resg,(FN fr,DN dr)),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
+          return rr
+      -- ((FN fr,DN dr),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
+      ((FN fr,DN dr),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
 
       -- ---------------------
       -- Free Vars - parsed
@@ -580,7 +579,8 @@ spec = do
                    "(GHC.Base.$, (-1, -1)),\n "++
                    "(GHC.List.head, (-1, -1)), "++
                    "(GHC.List.zip, (-1, -1)),\n "++
-                   "(System.IO.getChar, (-1, -1)), "++
+                   "(GHC.Base.String, (-1, -1)), "++
+                   "(System.IO.getChar, (-1, -1)),\n "++
                    "(System.IO.putStrLn, (-1, -1)),\n "++
                    "(Data.Generics.Text.gshow, (-1, -1))]"
 
@@ -605,42 +605,6 @@ spec = do
                    "(FreeAndDeclared.Declare.mkT, (34, 1)),\n "++
                    "(FreeAndDeclared.Declare.ff, (36, 1))]"
 
-      -- ---------------------
-      -- GHC version
-      -- Free Vars
-      (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (fst resg)) `shouldBe`
-                   "[(GHC.Integer.Type.Integer, (-1, -1)), "++
-                   "(GHC.Num.*, (-1, -1)),\n "++
-                   "(GHC.Types.Int, (-1, -1)), "++
-                   "(GHC.Base.$, (-1, -1)),\n "++
-                   "(GHC.List.head, (-1, -1)), "++
-                   "(GHC.List.zip, (-1, -1)),\n "++
-                   "(System.IO.getChar, (-1, -1)), "++
-                   "(System.IO.putStrLn, (-1, -1)),\n "++
-                   "(Data.Generics.Text.gshow, (-1, -1))]"
-
-      -- Declared Vars
-      (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (snd resg)) `shouldBe`
-                  "[(FreeAndDeclared.Declare.toplevel, (6, 1)),\n "++
-                  "(FreeAndDeclared.Declare.c, (9, 1)),\n "++
-                  "(FreeAndDeclared.Declare.d, (10, 1)),\n "++
-                  "(FreeAndDeclared.Declare.tup, (16, 1)),\n "++
-                  "(FreeAndDeclared.Declare.h, (16, 6)),\n "++
-                  "(FreeAndDeclared.Declare.t, (16, 8)),\n "++
-                  "(FreeAndDeclared.Declare.D, (18, 1)),\n "++
-                  "(FreeAndDeclared.Declare.A, (18, 10)),\n "++
-                  "(FreeAndDeclared.Declare.B, (18, 14)),\n "++
-                  "(FreeAndDeclared.Declare.C, (18, 25)),\n "++
-                  "(FreeAndDeclared.Declare.unD, (21, 1)),\n "++
-                  "(FreeAndDeclared.Declare.F, (25, 1)),\n "++
-                  "(FreeAndDeclared.Declare.G, (25, 10)),\n "++
-                  "(FreeAndDeclared.Declare.:|, (25, 14)),\n "++
-                  "(FreeAndDeclared.Declare.unF, (27, 1)),\n "++
-                  "(FreeAndDeclared.Declare.main, (30, 1)),\n "++
-                  "(FreeAndDeclared.Declare.mkT, (34, 1)),\n "++
-                  "(FreeAndDeclared.Declare.ff, (36, 1))]"
-
-
     -- ---------------------------------
 
     it "finds free and declared in a single bind PrefixCon" $ do
@@ -651,7 +615,6 @@ spec = do
         comp = do
           parsed <- getRefactParsed
           decls <- liftT $ hsDecls parsed
-          -- let b = head $ drop 4 $ hsBinds renamed
           let b = head $ drop 10 $ decls
           rg <- hsFreeAndDeclaredPNs [b]
           return (b,rg)
@@ -661,7 +624,6 @@ spec = do
       (showGhcQual bb) `shouldBe` "unD (B y) = y"
       -- (SYB.showData SYB.Renamer 0 bb) `shouldBe` ""
 
-      -- GHC version
       -- Free Vars
       (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (fst resg)) `shouldBe`
                    "[(FreeAndDeclared.Declare.B, (18, 14))]"
@@ -679,7 +641,6 @@ spec = do
         comp = do
           parsed <- getRefactParsed
           decls <- liftT $ hsDecls parsed
-          -- let b = head $ drop 3 $ hsBinds renamed
           let b = head $ drop 12 $ decls
           rg <- hsFreeAndDeclaredPNs [b]
           return (b,rg)
@@ -688,7 +649,6 @@ spec = do
       (showGhcQual bb) `shouldBe` "unF (a :| b) = (a, b)"
       -- (SYB.showData SYB.Renamer 0 bb) `shouldBe` ""
 
-      -- GHC version
       -- Free Vars
       (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (fst resg)) `shouldBe`
                    "[(FreeAndDeclared.Declare.:|, (25, 14))]"
@@ -706,7 +666,6 @@ spec = do
         comp = do
           parsed <- getRefactParsed
           decls <- liftT $ hsDecls parsed
-          -- let b = head $ drop 0 $ hsBinds renamed
           let b = head $ drop 2 decls
           rg <- hsFreeAndDeclaredPNs [b]
           return (b,rg)
@@ -716,7 +675,6 @@ spec = do
       (showGhcQual bb) `shouldBe` "unR2 (RCon {r1 = a}) = a"
       -- (SYB.showData SYB.Renamer 0 bb) `shouldBe` ""
 
-      -- GHC version
       -- Free Vars
       (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (fst resg)) `shouldBe`
                    "[(FreeAndDeclared.DeclareRec.RCon, (3, 10))]"
@@ -724,6 +682,38 @@ spec = do
       -- Declared Vars
       (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (snd resg)) `shouldBe`
                    "[(FreeAndDeclared.DeclareRec.unR2, (7, 1))]"
+
+    -- ---------------------------------
+
+    it "finds free and declared in a RecCon data declaration" $ do
+      t <- ct $ parsedFileGhc "./Renaming/Field1.hs"
+
+      let
+        comp = do
+          parsed <- getRefactParsed
+          decls <- liftT $ hsDecls parsed
+          let b = head $ drop 0 decls
+          rg <- hsFreeAndDeclaredPNs b
+          return (b,rg)
+      -- ((bb,resg),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
+      ((bb,resg),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
+
+
+      (showGhcQual bb) `shouldBe` "data Point\n  = Pt {pointx, pointy :: Float}\n  deriving (Show)"
+
+      -- (SYB.showData SYB.Renamer 0 bb) `shouldBe` ""
+
+      -- Free Vars
+      (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (fst resg)) `shouldBe`
+                   "[(GHC.Types.Float, (-1, -1)), "++
+                   "(GHC.Show.Show, (-1, -1))]"
+
+      -- Declared Vars
+      (showGhcQual $ map (\n -> (n, getGhcLoc $ GHC.nameSrcSpan n)) (snd resg)) `shouldBe`
+                   "[(Field1.Point, (5, 1)), "++
+                   "(Field1.Pt, (5, 14)),\n "++
+                   "(Field1.pointx, (5, 18)), "++
+                   "(Field1.pointy, (5, 26))]"
 
     -- -----------------------------------------------------------------
 
@@ -779,7 +769,6 @@ spec = do
       let
         comp = do
           parsed <- getRefactParsed
-          -- r <- hsFreeAndDeclaredPNs $ hsBinds renamed
           r <- hsFreeAndDeclaredPNs parsed
           return r
       ((res),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
@@ -1019,7 +1008,6 @@ spec = do
         comp = do
           nm <- getRefactNameMap
           fds' <- hsVisibleDsRdr nm (rdrName2NamePure nm e) rhs
-          -- ffds <- hsFreeAndDeclaredGhc rhsr
           let ffds = hsFreeAndDeclaredRdr nm rhs
           return (fds',ffds)
       -- ((fds,_fds),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
@@ -1043,14 +1031,12 @@ spec = do
           -- logDataWithAnns "parsed" parsed
           nm <- getRefactNameMap
           fds' <- hsVisibleDsRdr nm (rdrName2NamePure nm ln) parsed
-          -- ffds <- hsFreeAndDeclaredGhc renamed
           let ffds = hsFreeAndDeclaredRdr nm parsed
           return (fds',ffds)
       ((fds,_fds),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
       -- ((fds,_fds),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
 
-      (show _fds) `shouldBe` "(FN [a, "++
-                                  "GHC.Base.++, "++
+      (show _fds) `shouldBe` "(FN [GHC.Base.++, "++
                                   "GHC.Types.Int, "++
                                   "GHC.Classes.==, "++
                                   "GHC.Classes./=, "++
@@ -1146,7 +1132,6 @@ spec = do
           let lpat = head pats
           logDataWithAnns "lpat" lpat
 
-          -- fds' <- hsFreeAndDeclaredGhc $ lpat
           let fds' = hsFreeAndDeclaredRdr nm lpat
           return (fds')
       -- ((fds),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
@@ -1199,7 +1184,6 @@ spec = do
           let (GHC.L _ (GHC.Match _ _pats _rhs binds)) = match
 
           logDataWithAnns "binds" binds
-          -- fds' <- hsFreeAndDeclaredGhc $ binds
           let fds' = hsFreeAndDeclaredRdr nm binds
           return (fds')
       -- ((fds),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions

--- a/test/TypeUtilsSpec.hs
+++ b/test/TypeUtilsSpec.hs
@@ -464,6 +464,17 @@ spec = do
 
     -- ---------------------------------
 
+    it "finds field names in data declarations" $ do
+      t <- ct $ parsedFileGhc "./Renaming/Field4.hs"
+      let parsed = GHC.pm_parsed_source $ tmParsedModule t
+          nm = initRdrNameMap t
+
+      let Just n = locToNameRdrPure nm (5,23) parsed
+      let res = definingTyClDeclsNames nm [n] parsed
+      (unspace $ showGhcQual res) `shouldBe` "[data Vtree a\n = Vleaf {value1 :: a} |\n Vnode {value2 :: a, left, right :: Vtree a}]"
+
+    -- ---------------------------------
+
     it "finds type declarations" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/TyClDecls.hs"
       let parsed = GHC.pm_parsed_source $ tmParsedModule t
@@ -784,7 +795,7 @@ spec = do
       ((bb,resg),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
 
 
-      (showGhcQual bb) `shouldBe` "class SameOrNot a where\n  isSame :: a -> a -> Bool\n  isNotSame :: a -> a -> Bool"
+      (showGhcQual bb) `shouldBe` "class SameOrNot c where\n  isSame :: c -> c -> Bool\n  isNotSame :: c -> c -> Bool"
 
       -- (SYB.showData SYB.Renamer 0 bb) `shouldBe` ""
 
@@ -1559,7 +1570,7 @@ spec = do
 
          (parent',Just (funBinding,declsToDup,declsp')) <- modifyValD (GHC.getLoc parent) parent $ \_m declsp -> do
            let
-             declsToDup = definingDeclsRdrNames nm [n] declsp True True
+             declsToDup = definingDeclsRdrNames nm [n] declsp False True
              funBinding = filter isFunOrPatBindP declsToDup     --get the fun binding.
 
            declsp' <- duplicateDecl declsp n newName2
@@ -2171,7 +2182,7 @@ spec = do
          let Just tl = locToNameRdrPure nm (4, 1) parsed
          decls <- liftT (hsDecls parsed)
          let
-             [tlDecl] = definingDeclsRdrNames nm [tl] decls True False
+             [tlDecl] = definingDeclsRdrNames nm [tl] decls False False
 
          (decl,declAnns) <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "decl" "nn = nn2")
 
@@ -2198,7 +2209,7 @@ spec = do
          let Just tl = locToNameRdrPure nm (4, 1) parsed
          decls <- liftT (hsDecls parsed)
          let
-             [tlDecl] = definingDeclsRdrNames nm [tl] decls True False
+             [tlDecl] = definingDeclsRdrNames nm [tl] decls False False
 
          (decl,declAnns) <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "decl" "nn = nn2")
          (sig, sigAnns)  <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "sig"  "nn :: Int")
@@ -2225,7 +2236,7 @@ spec = do
          let Just tl = locToNameRdrPure nm (4, 1) parsed
          decls <- liftT (hsDecls parsed)
          let
-             [tlDecl] = definingDeclsRdrNames nm [tl] decls True False
+             [tlDecl] = definingDeclsRdrNames nm [tl] decls False False
 
          (decl,declAnns) <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "decl" "nn = nn2")
 
@@ -2250,7 +2261,7 @@ spec = do
          let Just tl = locToNameRdrPure nm (4, 1) parsed
          decls <- liftT (hsDecls parsed)
          let
-             [tlDecl] = definingDeclsRdrNames nm [tl] decls True False
+             [tlDecl] = definingDeclsRdrNames nm [tl] decls False False
 
          (decl,declAnns) <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "decl" "nn = nn2")
 
@@ -2276,7 +2287,7 @@ spec = do
          let Just tl = locToNameRdrPure nm (4, 1) parsed
          decls <- liftT (hsDecls parsed)
          let
-             [tlDecl] = definingDeclsRdrNames nm [tl] decls True False
+             [tlDecl] = definingDeclsRdrNames nm [tl] decls False False
 
          (decl,declAnns) <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "decl" "nn = nn2")
          (sig, sigAnns)  <- GHC.liftIO $ withDynFlags (\df -> parseDeclToAnnotated df "sig"  "nn :: Int")

--- a/test/TypeUtilsSpec.hs
+++ b/test/TypeUtilsSpec.hs
@@ -262,6 +262,28 @@ spec = do
       -}
       pending -- "Convert to definingDeclsNames"
 
+    -- ---------------------------------
+
+    it "finds a name declared in a RecCon data declaration" $ do
+      t <- ct $ parsedFileGhc "./Renaming/Field1.hs"
+
+      let
+        comp = do
+          parsed <- getRefactParsed
+          decls <- liftT $ hsDecls parsed
+          nm <- getRefactNameMap
+          let Just n = locToNameRdrPure nm (5,18) parsed
+          let rg = definingDeclsRdrNames nm [n] decls False False
+          return (n,rg)
+      -- ((bb,resg),_s) <- runRefactGhc comp (initialLogOnState { rsModule = initRefactModule [] t }) testOptions
+      ((nn,resg),_s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
+
+
+      (showGhcQual nn) `shouldBe` "Field1.pointx"
+
+      (showGhcQual resg) `shouldBe` "[data Point\n   = Pt {pointx, pointy :: Float}\n   deriving (Show)]"
+
+  -- ---------------------------------------
   -- -------------------------------------------------------------------
 {-
   describe "definingDeclsNames" $ do
@@ -3824,7 +3846,7 @@ spec = do
 
       (showGhcQual (r,n)) `shouldBe` "(bar, bar)"
 
-  -- ---------------------------------------
+  -- ---------------------------------------------------------------------
 
 myShow :: GHC.RdrName -> String
 myShow n = case n of

--- a/test/testdata/FreeAndDeclared/Declare.hs
+++ b/test/testdata/FreeAndDeclared/Declare.hs
@@ -4,7 +4,7 @@ import qualified Data.Generics as G
 
 toplevel :: Integer -> Integer
 toplevel x = c * x
- 
+
 c,d :: Integer
 c = 7
 d = 9

--- a/test/testdata/FreeAndDeclared/Declare2.hs
+++ b/test/testdata/FreeAndDeclared/Declare2.hs
@@ -4,7 +4,7 @@ import qualified Data.Generics as G
 
 toplevel :: Integer -> Integer
 toplevel x = c * x
- 
+
 c,d :: Integer
 c = 7
 d = 9

--- a/test/testdata/Renaming/D1.hs
+++ b/test/testdata/Renaming/D1.hs
@@ -5,17 +5,17 @@ module Renaming.D1 where
 
 data Tree a = Leaf a | Branch (Tree a) (Tree a)
 
-fringe :: Tree a -> [a]
+fringe :: Tree b -> [b]
 fringe (Leaf x ) = [x]
 fringe (Branch left right) = fringe left ++ fringe right
 
-class SameOrNot a where
-   isSame  :: a -> a -> Bool
-   isNotSame :: a -> a -> Bool
+class SameOrNot c where
+   isSame  :: c -> c -> Bool
+   isNotSame :: c -> c -> Bool
 
 instance SameOrNot Int where
-   isSame a  b = a == b
-   isNotSame a b = a /= b
+   isSame d  e = d == e
+   isNotSame d e = d /= e
 
 sumSquares (x:xs) = sq x + sumSquares xs
     where sq x = x ^pow

--- a/test/testdata/Renaming/D1.hs.expected
+++ b/test/testdata/Renaming/D1.hs.expected
@@ -5,17 +5,17 @@ module Renaming.D1 where
 
 data AnotherTree a = Leaf a | Branch (AnotherTree a) (AnotherTree a)
 
-fringe :: AnotherTree a -> [a]
+fringe :: AnotherTree b -> [b]
 fringe (Leaf x ) = [x]
 fringe (Branch left right) = fringe left ++ fringe right
 
-class SameOrNot a where
-   isSame  :: a -> a -> Bool
-   isNotSame :: a -> a -> Bool
+class SameOrNot c where
+   isSame  :: c -> c -> Bool
+   isNotSame :: c -> c -> Bool
 
 instance SameOrNot Int where
-   isSame a  b = a == b
-   isNotSame a b = a /= b
+   isSame d  e = d == e
+   isNotSame d e = d /= e
 
 sumSquares (x:xs) = sq x + sumSquares xs
     where sq x = x ^pow

--- a/test/testdata/Renaming/Field1.hs
+++ b/test/testdata/Renaming/Field1.hs
@@ -2,7 +2,7 @@ module Field1 where
 
 --Rename field name 'pointx' to 'pointx1'
 
-data Point = Pt {pointx, pointy :: Float}
+data Point = Pt {pointx, pointy :: Float} deriving Show
 
 absPoint :: Point -> Float
 absPoint p = sqrt (pointx p * pointx p +

--- a/test/testdata/Renaming/Field1.hs.expected
+++ b/test/testdata/Renaming/Field1.hs.expected
@@ -2,7 +2,7 @@ module Field1 where
 
 --Rename field name 'pointx' to 'pointx1'
 
-data Point = Pt {pointx1, pointy :: Float}
+data Point = Pt {pointx1, pointy :: Float} deriving Show
 
 absPoint :: Point -> Float
 absPoint p = sqrt (pointx1 p * pointx1 p +

--- a/test/testdata/Renaming/Field4.hs
+++ b/test/testdata/Renaming/Field4.hs
@@ -2,7 +2,7 @@ module Field4 where
 
 --Rename field name 'value1' to 'value2' should success.
 
-data Vtree a = Vleaf {value1::a} | 
+data Vtree a = Vleaf {value1::a} |
                Vnode {value2::a, left,right ::Vtree a}
 
 fringe :: Vtree a -> [a]

--- a/test/testdata/Renaming/InScopes.hs
+++ b/test/testdata/Renaming/InScopes.hs
@@ -1,0 +1,21 @@
+module Renaming.InScopes where
+
+-- based on https://github.com/RefactoringTools/HaRe/issues/41
+
+-- renaming x to g should fail for a name clash, in all cases
+f x = let g = 'g' in x
+
+f1 x = do
+  let g = 'g'
+  return x
+
+f2 x = x
+  where
+    g = 'g'
+
+-- Renaming f to g should also fail, esp when the initial point is the function
+-- definition for f
+f3 x = y
+  where
+    g = f 'g'
+    y = f2 x

--- a/test/testdata/Renaming/LayoutIn3.hs
+++ b/test/testdata/Renaming/LayoutIn3.hs
@@ -7,7 +7,6 @@ module LayoutIn3 where
 foo x = let x = 12 in (let y = 3
                            z = 2 in x * y * z * w) where   y = 2
                                                            --there is a comment.
-                                                           w = x  
+                                                           w = x
                                                              where
                                                                x = let y = 5 in y + 3
-

--- a/test/testdata/Renaming/LayoutIn3.hs.expected
+++ b/test/testdata/Renaming/LayoutIn3.hs.expected
@@ -10,4 +10,3 @@ foo x = let anotherX = 12 in (let y = 3
                                                                          w = x
                                                                            where
                                                                              x = let y = 5 in y + 3
-


### PR DESCRIPTION
Closest #41 

It will report a name clash for renaming `x` to `g` in each of the following

```haskell
f x = let g = 'g' in x

f1 x = do
  let g = 'g'
  return x

f2 x = x
  where
    g = 'g'

f3 x = y
  where
    g = f 'g'
    y = f2 x
```