### PR TITLE
Small changes to Gen Applicative refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
  - cabal configure --disable-optimization --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal haddock
- - travis_long cabal test --show-details=streaming
+ - ./travis_long cabal test --show-details=streaming
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
  - emacs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
  - cabal configure --disable-optimization --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal haddock
- - cabal test --show-details=streaming
+ - travis_long cabal test --show-details=streaming
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
  - emacs --version

--- a/app/MainHaRe.hs
+++ b/app/MainHaRe.hs
@@ -110,7 +110,7 @@ data HareParams = DemoteCmd      FilePath Row Col
                 | RenameCmd      FilePath String Row Col
                 | AddOneParam    FilePath String Row Col
                 | RmOneParam     FilePath Row Col
-                | GenApplicative FilePath String Row Col
+                | GenApplicative FilePath Row Col
                 | DeleteDef      FilePath Row Col
                deriving Show
 
@@ -139,8 +139,8 @@ runCmd (AddOneParam fileName newname r c) (opt, gOpt)
 runCmd (RmOneParam fileName r c) (opt, gOpt)
   = runFunc $ rmOneParameter opt gOpt fileName (r,c)
 
-runCmd (GenApplicative fileName funNm r c) (opt, gOpt)
-  = runFunc $ genApplicative opt gOpt fileName funNm (r,c)
+runCmd (GenApplicative fileName r c) (opt, gOpt)
+  = runFunc $ genApplicative opt gOpt fileName (r,c)
 
 runCmd (DeleteDef fileName r c) (opt, gOpt)
   = runFunc $ deleteDef opt gOpt fileName (r,c)
@@ -295,10 +295,6 @@ genApplicativeOpts =
           ( metavar "FILE"
          <> help "Specify Haskell file to process"
           )
-      <*> strArgument
-            ( metavar "FUNNAME"
-           <> help "The name of the function to be refactored"
-            )
       <*> argument auto
             ( metavar "line"
            <> help "The line the definition is on")

--- a/src/Language/Haskell/Refact/Utils/Query.hs
+++ b/src/Language/Haskell/Refact/Utils/Query.hs
@@ -25,8 +25,8 @@ getVarAndRHS match = do
           varPat _ = Nothing
 
 --Looks up the function binding at the given position. Returns nothing if the position does not contain a binding.
-getHsBind :: (Data a) => SimpPos -> String -> a -> Maybe (GHC.HsBind GHC.RdrName)
-getHsBind pos funNm a =
+getHsBind :: (Data a) => SimpPos -> a -> Maybe (GHC.HsBind GHC.RdrName)
+getHsBind pos a =
   let rdrNm = locToRdrName pos a in
   case rdrNm of
   Nothing -> Nothing

--- a/test/GenApplicativeSpec.hs
+++ b/test/GenApplicativeSpec.hs
@@ -13,7 +13,7 @@ spec :: Spec
 spec = do
   describe "doGenApplicative" $ do
     it "Simple parser that can be easily rewritten in the applicative style." $ do
-      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA1.hs" "parseStr" (4,1)
+      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA1.hs" (4,1)
       -- res <- ct $ genApplicative logTestSettings testOptions "./GenApplicative/GA1.hs" "parseStr" (4,1)
       res' <- ct $ mapM makeRelativeToCurrentDirectory res
       res' `shouldBe` ["GenApplicative/GA1.hs"]
@@ -21,27 +21,27 @@ spec = do
                                 "./GenApplicative/GA1.hs.expected"
       diff `shouldBe` []
     it "A slightly more complicated parser" $ do
-      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA2.hs" "objEntry" (7,1)
+      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA2.hs" (7,1)
       res' <- ct $ mapM makeRelativeToCurrentDirectory res
       res' `shouldBe` ["GenApplicative/GA2.hs"]
       diff <- ct $ compareFiles "./GenApplicative/GA2.refactored.hs"
                                 "./GenApplicative/GA2.hs.expected"
       diff `shouldBe` []
     it "A more complicated pure expression needs to be formed." $ do
-      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA3.hs" "zipperM" (4,1)
+      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA3.hs" (4,1)
       res' <- ct $ mapM makeRelativeToCurrentDirectory res
       res' `shouldBe` ["GenApplicative/GA3.hs"]
       diff <- ct $ compareFiles "./GenApplicative/GA3.refactored.hs"
                                 "./GenApplicative/GA3.hs.expected"
       diff `shouldBe` []
     it "This function should not pass the precondition because a bound variable is used in a rhs." $ do
-      res <- catchException (ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA4.hs" "failBoundPrecon" (4,1))
+      res <- catchException (ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA4.hs"  (4,1))
       (show res) `shouldBe` "Just \"GenApplicative Precondition: The function given uses a bound variable in a RHS expression.\""
     it "This function should not pass the precondition because variables are bound out of order" $ do
-      res <- catchException (ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA4.hs" "failOrderPrecon" (10,1))
+      res <- catchException (ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/GA4.hs" (10,1))
       (show res) `shouldBe` "Just \"GenApplicative Precondition: Variables are not bound in the order that they appear in the return statement.\""
     it "Debugging a function from html-tokenizer" $ do
-      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/HTMLTokenizer.hs" "openingTag" (88,1)
+      res <- ct $ genApplicative defaultTestSettings testOptions "./GenApplicative/HTMLTokenizer.hs" (88,1)
       -- res <- ct $ genApplicative logTestSettings testOptions "./GenApplicative/HTMLTokenizer.hs" "openingTag" (88,1)
       res' <- ct $ mapM makeRelativeToCurrentDirectory res
       res' `shouldBe` ["GenApplicative/HTMLTokenizer.hs"]


### PR DESCRIPTION
Two changes to gen applicative. 

1. Added error messages if the target function doesn't exist at the specified position or is not do statement.
2. Removed the function name parameter that was not being used.
