### PR TITLE
Fixed an issue in addImportDecl

### DIFF
--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -869,7 +869,10 @@ addImportDecl (GHC.L l p) modName pkgQual source safe qualify alias hide idNames
        newEnts <- mkNewEntList idNames
        let lNewEnts = GHC.L newSpan2 newEnts
        -- logm $ "addImportDecl.mkImpDecl:adding anns for:" ++ showGhc lNewEnts
-       liftT $ addSimpleAnnT lNewEnts (DP (0,1)) [((G GHC.AnnHiding),DP (0,0)),((G GHC.AnnOpenP),DP (0,1)),((G GHC.AnnCloseP),DP (0,0))]
+           newEntsAnns = if hide
+             then [((G GHC.AnnHiding),DP (0,0)),((G GHC.AnnOpenP),DP (0,1)),((G GHC.AnnCloseP),DP (0,0))]
+             else [((G GHC.AnnOpenP),DP (0,0)),((G GHC.AnnCloseP),DP (0,0))]
+       liftT $ addSimpleAnnT lNewEnts (DP (0,1)) newEntsAnns
        let lmodname = GHC.L newSpan1 modName
        liftT $ addSimpleAnnT lmodname (DP (0,1)) [((G GHC.AnnVal),DP (0,0))]
        return $ GHC.ImportDecl

--- a/src/Language/Haskell/Refact/Utils/TypeUtils.hs
+++ b/src/Language/Haskell/Refact/Utils/TypeUtils.hs
@@ -855,7 +855,8 @@ addImportDecl (GHC.L l p) modName pkgQual source safe qualify alias hide idNames
        impDecl <- mkImpDecl
        newSpan <- liftT uniqueSrcSpanT
        let newImp = GHC.L newSpan impDecl
-       liftT $ addSimpleAnnT newImp (DP (1,0)) [((G GHC.AnnImport),DP (0,0))]
+           qAnns = getQualAnns alias qualify
+       liftT $ addSimpleAnnT newImp (DP (1,0)) ([((G GHC.AnnImport),DP (0,0))]++qAnns)
        return (GHC.L l p { GHC.hsmodImports = (imp++[newImp])})
   where
 
@@ -890,6 +891,10 @@ addImportDecl (GHC.L l p) modName pkgQual source safe qualify alias hide idNames
                                        else
                                             (Just (hide, lNewEnts)))
                         }
+     getQualAnns Nothing _ = []
+     getQualAnns (Just _) q = let cond = if q then [((G GHC.AnnQualified), DP (0,1))] else [] in
+         [((G GHC.AnnAs), DP (0,1)),((G GHC.AnnVal), (DP (0,1)))] ++ cond
+
 
 -- ---------------------------------------------------------------------
 

--- a/test/TypeUtilsSpec.hs
+++ b/test/TypeUtilsSpec.hs
@@ -3666,6 +3666,25 @@ spec = do
 
   -- ---------------------------------------
 
+    it "adds an import entry that only imports a single name" $ do
+      t <- ct $ parsedFileGhc "./TypeUtils/Empty.hs"
+      let
+        comp = do
+         renamed1 <- getRefactRenamed
+         parsed <- getRefactParsed
+         let listModName  = GHC.mkModuleName "Data.List"
+             rdr          = mkRdrName "head"
+         res  <- addImportDecl parsed listModName Nothing False False False Nothing False [rdr]
+         putRefactParsed res emptyAnns
+
+         return (res,renamed1)
+      ((_r,_r2),s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
+
+      (sourceFromState s) `shouldBe` "module Empty where\nimport Data.List (head)\n\n"
+
+
+  -- ---------------------------------------
+
   describe "addItemsToImport" $ do
     it "adds an item to an import entry with no items" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/JustImports.hs"

--- a/test/TypeUtilsSpec.hs
+++ b/test/TypeUtilsSpec.hs
@@ -3685,6 +3685,25 @@ spec = do
 
   -- ---------------------------------------
 
+    it "adds a qualified import" $ do
+      t <- ct $ parsedFileGhc "./TypeUtils/Empty.hs"
+      let
+        comp = do
+         renamed1 <- getRefactRenamed
+         parsed <- getRefactParsed
+         let listModName  = GHC.mkModuleName "Data.List"
+             qual = Just "List"
+         res  <- addImportDecl parsed listModName Nothing False False True qual False []
+         putRefactParsed res emptyAnns
+
+         return (res,renamed1)
+      ((_r,_r2),s) <- runRefactGhc comp (initialState { rsModule = initRefactModule [] t }) testOptions
+
+      (sourceFromState s) `shouldBe` "module Empty where\nimport qualified Data.List as List\n\n"
+
+
+  -- ---------------------------------------
+
   describe "addItemsToImport" $ do
     it "adds an item to an import entry with no items" $ do
       t <- ct $ parsedFileGhc "./TypeUtils/JustImports.hs"


### PR DESCRIPTION
When adding an import that only imports some names e.g.
```
import Data.List (head) 
```

When calling addImportDecl hide will be false but idNames would be non-empty. The output includes two spaces between the module name and the list of imported identifiers e.g.

```
import Data.List  (head)
```

I check if the import is hidden and if it's not remove the annotation for the hiding keyword and the DP for the open parenthesis becomes (0,0).